### PR TITLE
Reduce network bandwith usage

### DIFF
--- a/src/NewRemoting/Client.cs
+++ b/src/NewRemoting/Client.cs
@@ -73,8 +73,8 @@ namespace NewRemoting
 				Logger.LogInformation("Client authentication done.");
 			}
 
-			_writer = new BinaryWriter(stream, Encoding.Unicode);
-			_reader = new BinaryReader(stream, Encoding.Unicode);
+			_writer = new BinaryWriter(stream, MessageHandler.DefaultStringEncoding);
+			_reader = new BinaryReader(stream, MessageHandler.DefaultStringEncoding);
 			_builder = new DefaultProxyBuilder();
 			_proxy = new ProxyGenerator(_builder);
 			_instanceManager = new InstanceManager(_proxy, instanceLogger);
@@ -121,7 +121,7 @@ namespace NewRemoting
 			// 1 - 4       | instance hash of this client
 			// 5 - 99      | reserved
 			// 100 - 103   | length of identifier
-			// 103 -       | our instance identifier in unicode
+			// 103 -       | our instance identifier in the default encoding
 			byte[] authenticationData = new byte[100];
 			authenticationData[0] = (byte)(callbackStream ? 1 : 0);
 
@@ -129,7 +129,7 @@ namespace NewRemoting
 			Array.Copy(BitConverter.GetBytes(instanceHash), 0, authenticationData, 1, 4);
 			destination.Write(authenticationData, 0, 100);
 
-			var instanceIdentifier = Encoding.Unicode.GetBytes(_instanceManager.InstanceIdentifier);
+			var instanceIdentifier = MessageHandler.DefaultStringEncoding.GetBytes(_instanceManager.InstanceIdentifier);
 			var lenBytes = BitConverter.GetBytes(instanceIdentifier.Length);
 
 			destination.Write(lenBytes);
@@ -163,7 +163,7 @@ namespace NewRemoting
 				return false;
 			}
 
-			_interceptor.OtherSideInstanceId = Encoding.Unicode.GetString(data);
+			_interceptor.OtherSideInstanceId = MessageHandler.DefaultStringEncoding.GetString(data);
 			return true;
 		}
 

--- a/src/NewRemoting/ClientSideInterceptor.cs
+++ b/src/NewRemoting/ClientSideInterceptor.cs
@@ -54,7 +54,7 @@ namespace NewRemoting
 			_logger = logger;
 			_pendingInvocations = new();
 			_terminator = new CancellationTokenSource();
-			_reader = new BinaryReader(_serverLink, Encoding.Unicode);
+			_reader = new BinaryReader(_serverLink, MessageHandler.DefaultStringEncoding);
 			_receiverThread = new Thread(ReceiverThread);
 			_receiverThread.Name = "ClientSideInterceptor - " + thisSideInstanceId;
 			_memoryCollectingThread = new Thread(MemoryCollectingThread);
@@ -108,7 +108,7 @@ namespace NewRemoting
 			int thisSeq = NextSequenceNumber();
 
 			using MemoryStream rawDataMessage = new MemoryStream(1024);
-			using BinaryWriter writer = new BinaryWriter(rawDataMessage, Encoding.Unicode);
+			using BinaryWriter writer = new BinaryWriter(rawDataMessage, MessageHandler.DefaultStringEncoding);
 
 			using CallContext ctx = CreateCallContext(invocation, thisSeq);
 
@@ -238,7 +238,7 @@ namespace NewRemoting
 				if (Interlocked.Increment(ref _numberOfCallsInspected) > NumberOfCallsForGc)
 				{
 					using MemoryStream rawDataMessage = new MemoryStream(1024);
-					using BinaryWriter writer = new BinaryWriter(rawDataMessage, Encoding.Unicode);
+					using BinaryWriter writer = new BinaryWriter(rawDataMessage, MessageHandler.DefaultStringEncoding);
 					_logger.LogInformation($"Starting GC on {ThisSideInstanceId}");
 					_messageHandler.InstanceManager.PerformGc(writer, false);
 					SafeSendToServer(rawDataMessage);

--- a/src/NewRemoting/MessageHandler.cs
+++ b/src/NewRemoting/MessageHandler.cs
@@ -35,6 +35,8 @@ namespace NewRemoting
 			_interceptors = new();
 		}
 
+		public static Encoding DefaultStringEncoding => Encoding.UTF8;
+
 		public InstanceManager InstanceManager => _instanceManager;
 
 		public static bool HasDefaultCtor(Type t)

--- a/src/NewRemoting/MessageHandler.cs
+++ b/src/NewRemoting/MessageHandler.cs
@@ -165,7 +165,10 @@ namespace NewRemoting
 			}
 			else if (t.IsSerializable)
 			{
-				SendSerializedObject(w, data, referencesWillBeSentTo);
+				if (!TryUseFastSerialization(w, t, data))
+				{
+					SendAutoSerializedObject(w, data, referencesWillBeSentTo);
+				}
 			}
 			else if (t.IsAssignableTo(typeof(MarshalByRefObject)))
 			{
@@ -183,7 +186,92 @@ namespace NewRemoting
 			}
 		}
 
-		private void SendSerializedObject(BinaryWriter w, object data, string otherSideInstanceId)
+		private bool TryUseFastSerialization(BinaryWriter w, Type objectType, object data)
+		{
+			if (objectType == typeof(Int32))
+			{
+				int i = (int)data;
+				w.Write((int)RemotingReferenceType.Int32);
+				w.Write(i);
+				return true;
+			}
+
+			if (objectType == typeof(UInt32))
+			{
+				UInt32 i = (UInt32)data;
+				w.Write((int)RemotingReferenceType.Uint32);
+				w.Write(i);
+				return true;
+			}
+
+			if (objectType == typeof(bool))
+			{
+				bool b = (bool)data;
+				w.Write((int)RemotingReferenceType.Bool);
+				w.Write(b);
+				return true;
+			}
+
+			if (objectType == typeof(Int16))
+			{
+				Int16 s = (Int16)data;
+				w.Write((int)RemotingReferenceType.Int16);
+				w.Write(s);
+				return true;
+			}
+
+			if (objectType == typeof(UInt16))
+			{
+				UInt16 s = (UInt16)data;
+				w.Write((int)RemotingReferenceType.Uint16);
+				w.Write(s);
+				return true;
+			}
+
+			if (objectType == typeof(sbyte))
+			{
+				sbyte s = (sbyte)data;
+				w.Write((int)RemotingReferenceType.Int8);
+				w.Write(s);
+				return true;
+			}
+
+			if (objectType == typeof(byte))
+			{
+				byte b = (byte)data;
+				w.Write((int)RemotingReferenceType.Uint8);
+				w.Write(b);
+				return true;
+			}
+
+			if (objectType == typeof(float))
+			{
+				float f = (float)data;
+				w.Write((int)RemotingReferenceType.Float);
+				w.Write(f);
+				return true;
+			}
+
+			if (objectType == typeof(Int64))
+			{
+				Int64 i = (Int64)data;
+				w.Write((int)RemotingReferenceType.Int64);
+				w.Write(i);
+				return true;
+			}
+
+			if (objectType == typeof(double))
+			{
+				double d = (double)data;
+				w.Write((int)RemotingReferenceType.Double);
+				w.Write(d);
+				return true;
+			}
+
+			return false;
+		}
+
+		private void SendAutoSerializedObject(BinaryWriter w, object data, string otherSideInstanceId)
 		{
 			MemoryStream ms = new MemoryStream();
 
@@ -194,30 +282,6 @@ namespace NewRemoting
 			w.Write((int)RemotingReferenceType.SerializedItem);
 			w.Write((int)ms.Length);
 			var array = ms.ToArray();
-
-			/*
-			// The following is for testing purposes only (slow!)
-			// It tests that the serialized code doesn't contain any serialized proxies. This has false positives when
-			// copying files from/to a remote endpoint, because dlls may contain the requested string.
-			byte[] compare = Encoding.ASCII.GetBytes("DynamicProxyGenAss");
-			for (int i = 0; i < array.Length; i++)
-			{
-				int needleIdx = 0;
-				while (needleIdx < compare.Length && array[i + needleIdx] == compare[needleIdx])
-				{
-					needleIdx++;
-				}
-
-				if (needleIdx >= compare.Length)
-				{
-					ms.Position = 0;
-#pragma warning disable 618
-					_formatter.Serialize(ms, data);
-#pragma warning restore 618
-					throw new RemotingException("Should not have serialized a dynamic proxy with its internal name");
-				}
-			}
-			*/
 
 			w.Write(array, 0, (int)ms.Length);
 		}
@@ -455,6 +519,66 @@ namespace NewRemoting
 				{
 					string s = r.ReadString();
 					return IPAddress.Parse(s);
+				}
+
+				case RemotingReferenceType.Bool:
+				{
+					bool b = r.ReadBoolean();
+					return b;
+				}
+
+				case RemotingReferenceType.Int32:
+				{
+					int i = r.ReadInt32();
+					return i;
+				}
+
+				case RemotingReferenceType.Uint32:
+				{
+					var i = r.ReadUInt32();
+					return i;
+				}
+
+				case RemotingReferenceType.Int8:
+				{
+					var i = r.ReadSByte();
+					return i;
+				}
+
+				case RemotingReferenceType.Uint8:
+				{
+					var i = r.ReadByte();
+					return i;
+				}
+
+				case RemotingReferenceType.Int16:
+				{
+					var i = r.ReadInt16();
+					return i;
+				}
+
+				case RemotingReferenceType.Uint16:
+				{
+					var i = r.ReadUInt16();
+					return i;
+				}
+
+				case RemotingReferenceType.Int64:
+				{
+					var i = r.ReadInt64();
+					return i;
+				}
+
+				case RemotingReferenceType.Float:
+				{
+					var i = r.ReadSingle();
+					return i;
+				}
+
+				case RemotingReferenceType.Double:
+				{
+					var i = r.ReadDouble();
+					return i;
 				}
 
 				case RemotingReferenceType.MethodPointer:

--- a/src/NewRemoting/RemotingReferenceType.cs
+++ b/src/NewRemoting/RemotingReferenceType.cs
@@ -6,7 +6,12 @@ using System.Threading.Tasks;
 
 namespace NewRemoting
 {
-	public enum RemotingReferenceType
+	/// <summary>
+	/// Header word in the data stream that identifies the parameter that follows.
+	/// The protocol does not use a length field or a tailer, so if the data size does not fit, the stream will loose
+	/// sync and the application will crash.
+	/// </summary>
+	internal enum RemotingReferenceType
 	{
 		Undefined = 0,
 		SerializedItem,
@@ -16,6 +21,16 @@ namespace NewRemoting
 		ArrayOfSystemType,
 		NullPointer,
 		ContainerType,
-		IpAddress
+		IpAddress,
+		Int8,
+		Uint8,
+		Int16,
+		Uint16,
+		Int32,
+		Int64,
+		Uint32,
+		Bool,
+		Float,
+		Double,
 	}
 }

--- a/src/NewRemoting/Server.cs
+++ b/src/NewRemoting/Server.cs
@@ -326,7 +326,7 @@ namespace NewRemoting
 			_threadRunning = true;
 			Thread ts = new Thread(ServerStreamHandler);
 			ts.Name = "Server stream handler for client side";
-			var td = new ThreadData(ts, _preopenedStream, new BinaryReader(_preopenedStream, Encoding.Unicode), otherSideInstanceId);
+			var td = new ThreadData(ts, _preopenedStream, new BinaryReader(_preopenedStream, MessageHandler.DefaultStringEncoding), otherSideInstanceId);
 			_threads.Add(td);
 			ts.Start(td);
 		}
@@ -390,7 +390,7 @@ namespace NewRemoting
 					int methodGenericArgs = r.ReadInt32(); // number of generic arguments of method (not generic arguments of declaring class!)
 
 					MemoryStream ms = new MemoryStream(4096);
-					BinaryWriter answerWriter = new BinaryWriter(ms, Encoding.Unicode);
+					BinaryWriter answerWriter = new BinaryWriter(ms, MessageHandler.DefaultStringEncoding);
 
 					if (hd.Function == RemotingFunctionType.CreateInstanceWithDefaultCtor)
 					{
@@ -856,7 +856,7 @@ namespace NewRemoting
 						LogToBoth("Server authentication done", LogLevel.Information);
 					}
 
-					using var reader = new BinaryReader(stream, Encoding.Unicode, true);
+					using var reader = new BinaryReader(stream, MessageHandler.DefaultStringEncoding, true);
 
 					byte[] authenticationToken = new byte[100];
 
@@ -898,7 +898,7 @@ namespace NewRemoting
 
 					LogToBoth("Server received client authentication", LogLevel.Information);
 
-					string otherSideInstanceId = Encoding.Unicode.GetString(data);
+					string otherSideInstanceId = MessageHandler.DefaultStringEncoding.GetString(data);
 					int instanceHash = BitConverter.ToInt32(authenticationToken, 1);
 
 					SendAuthenticationReply(stream);
@@ -914,7 +914,7 @@ namespace NewRemoting
 
 					Thread ts = new Thread(ServerStreamHandler);
 					ts.Name = $"Remote server client {tcpClient.Client.RemoteEndPoint}";
-					var td = new ThreadData(ts, stream, new BinaryReader(stream, Encoding.Unicode),
+					var td = new ThreadData(ts, stream, new BinaryReader(stream, MessageHandler.DefaultStringEncoding),
 						otherSideInstanceId);
 					_threads.Add(td);
 					ts.Start(td);
@@ -944,7 +944,7 @@ namespace NewRemoting
 			byte[] successToken = BitConverter.GetBytes(AuthenticationSucceededToken);
 			stream.Write(successToken);
 
-			var instanceIdentifier = Encoding.Unicode.GetBytes(_instanceManager.InstanceIdentifier);
+			var instanceIdentifier = MessageHandler.DefaultStringEncoding.GetBytes(_instanceManager.InstanceIdentifier);
 			var lenBytes = BitConverter.GetBytes(instanceIdentifier.Length);
 			stream.Write(lenBytes);
 			stream.Write(instanceIdentifier);
@@ -970,7 +970,7 @@ namespace NewRemoting
 			if (!disconnected)
 			{
 				MemoryStream ms = new MemoryStream();
-				BinaryWriter binaryWriter = new BinaryWriter(ms, Encoding.Unicode);
+				BinaryWriter binaryWriter = new BinaryWriter(ms, MessageHandler.DefaultStringEncoding);
 				RemotingCallHeader hdReturnValue = new RemotingCallHeader(RemotingFunctionType.ServerShuttingDown, 0);
 				hdReturnValue.WriteHeaderNoLock(binaryWriter);
 				foreach (var thread in _threads)

--- a/src/NewRemotingUnitTest/RemoteOperationsTest.cs
+++ b/src/NewRemotingUnitTest/RemoteOperationsTest.cs
@@ -626,6 +626,13 @@ namespace NewRemotingUnitTest
 			Assert.False(string.IsNullOrWhiteSpace(data));
 		}
 
+		[Test]
+		public void TestFastArgumentPassing()
+		{
+			var server = _client.CreateRemoteInstance<MarshallableClass>();
+			Assert.True(server.TakeSomeArguments(10, 2000, 2000, 10.0));
+		}
+
 		private void ExecuteCallbacks(IMarshallInterface instance, int overallIterations, int iterations,
 			ref int expectedCounter)
 		{

--- a/src/SampleServerClasses/MarshallableClass.cs
+++ b/src/SampleServerClasses/MarshallableClass.cs
@@ -274,5 +274,10 @@ namespace SampleServerClasses
 		{
 			return new SealedClass();
 		}
+
+		public virtual bool TakeSomeArguments(int a, Int16 b, UInt16 c, double d)
+		{
+			return Math.Abs(a + b - (c + d)) < 1E-12;
+		}
 	}
 }


### PR DESCRIPTION
- Most of the strings used are identifiers, and as such
are much shorter when encoded as UTF-8.
- Some often used data types can be serialized directly