### PR TITLE
Ensure the correct exception is thrown in all cases

### DIFF
--- a/src/NewRemoting/RemoteLoaderWindowsClient.cs
+++ b/src/NewRemoting/RemoteLoaderWindowsClient.cs
@@ -48,6 +48,9 @@ namespace NewRemoting
 			};
 		}
 
+		/// <summary>
+		/// The remote network port in use
+		/// </summary>
 		public int RemotePort
 		{
 			get;

--- a/src/NewRemotingUnitTest/ServerTerminationTest.cs
+++ b/src/NewRemotingUnitTest/ServerTerminationTest.cs
@@ -69,6 +69,33 @@ namespace NewRemotingUnitTest
 			}
 
 			Assert.True(didThrow);
+			didThrow = false;
+
+			try
+			{
+				_client.RequestRemoteInstance<IRemoteServerService>();
+			}
+			catch (RemotingException)
+			{
+				didThrow = true;
+			}
+
+			Assert.True(didThrow);
+			didThrow = false;
+			try
+			{
+				_client.CreateRemoteInstance<TestDummy>();
+			}
+			catch (RemotingException)
+			{
+				didThrow = true;
+			}
+
+			Assert.True(didThrow);
+		}
+
+		public class TestDummy : MarshalByRefObject
+		{
 		}
 	}
 }


### PR DESCRIPTION
Any failed remote calls should throw a RemotingException, regardless of the internal cause.