### PR TITLE
Fix a rare, but serious race condition updating the instance list

### DIFF
--- a/src/NewRemoting/FormatterFactory.cs
+++ b/src/NewRemoting/FormatterFactory.cs
@@ -92,7 +92,7 @@ namespace NewRemoting
 				}
 				else
 				{
-					objectId = _instanceManager.GetIdForObject(obj, (string)context.Context);
+					objectId = _instanceManager.RegisterRealObjectAndGetId(obj, (string)context.Context);
 					info.AddValue("ObjectId", objectId);
 					info.AddValue("AssemblyQualifiedName", obj.GetType().AssemblyQualifiedName);
 				}

--- a/src/NewRemotingUnitTest/AuthenticationTests.cs
+++ b/src/NewRemotingUnitTest/AuthenticationTests.cs
@@ -57,8 +57,8 @@ namespace NewRemotingUnitTest
 			FileInfo fi = new FileInfo(Assembly.GetExecutingAssembly().Location);
 			var psi = new ProcessStartInfo(Path.Combine(fi.DirectoryName, "RemotingServer.exe"));
 
-			Console.WriteLine($"Attempting to start {psi.FileName}...");
-			Console.WriteLine($"Current directory is {Environment.CurrentDirectory}");
+			Debug.WriteLine($"Attempting to start {psi.FileName}...");
+			Debug.WriteLine($"Current directory is {Environment.CurrentDirectory}");
 
 			using (var serverProcess = Process.Start(psi))
 			{

--- a/src/NewRemotingUnitTest/RemoteOperationsTest.cs
+++ b/src/NewRemotingUnitTest/RemoteOperationsTest.cs
@@ -745,6 +745,18 @@ namespace NewRemotingUnitTest
 			CreateClientServer();
 			var server = _client.CreateRemoteInstance<MarshallableClass>();
 			Assert.True(server.TakeSomeArguments(10, 2000, 2000, 10.0));
+			Assert.True(server.TakeSomeMoreArguments(10, 2000, 2000, 10.0f));
+		}
+
+		[Test]
+		public void TestTypeAsArguments()
+		{
+			CreateClientServer();
+			var server = _client.CreateRemoteInstance<MarshallableClass>();
+			var result = server.ProcessListOfTypes();
+			Assert.IsEmpty(result);
+			result = server.ProcessListOfTypes(typeof(string), typeof(Int32), typeof(bool), null);
+			Assert.False(string.IsNullOrWhiteSpace(result));
 		}
 
 		private void ExecuteCallbacks(IMarshallInterface instance, int overallIterations, int iterations,

--- a/src/SampleServerClasses/MarshallableClass.cs
+++ b/src/SampleServerClasses/MarshallableClass.cs
@@ -281,5 +281,15 @@ namespace SampleServerClasses
 		{
 			return Math.Abs(a + b - (c + d)) < 1E-12;
 		}
+
+		public virtual bool TakeSomeMoreArguments(byte a, short b, ushort c, float d)
+		{
+			return Math.Abs(a + b - (c + d)) < 1E-12;
+		}
+
+		public virtual string ProcessListOfTypes(params Type[] types)
+		{
+			return string.Join(", ", types.Select(x => x?.ToString()));
+		}
 	}
 }


### PR DESCRIPTION
AddInstance may return the old instance in case of a race condition
now. This must be properly handled.