### PR TITLE
Disable manual serialization of arrays for testing

### DIFF
--- a/src/NewRemoting/MessageHandler.cs
+++ b/src/NewRemoting/MessageHandler.cs
@@ -493,21 +493,23 @@ namespace NewRemoting
 					return true;
 				}
 
-				case byte[] byteArray:
-				{
-					w.Write((int)RemotingReferenceType.ByteArray);
-					LogMsg(RemotingReferenceType.ByteArray);
-					if (byteArray.Length == 0)
-					{
-						// See above
-						w.Write(0);
-						return true;
-					}
+					// This code is suspected of causing "Fatal error. Internal CLR error. (0x80131506)"
+					// No idea why this should be different to using standard serialization. Or simulation, by the way.
+					////case byte[] byteArray:
+					////{
+					////	w.Write((int)RemotingReferenceType.ByteArray);
+					////	LogMsg(RemotingReferenceType.ByteArray);
+					////	if (byteArray.Length == 0)
+					////	{
+					////		// See above
+					////		w.Write(0);
+					////		return true;
+					////	}
 
-					w.Write(byteArray.Length);
-					w.Write(byteArray, 0, byteArray.Length);
-					return true;
-				}
+					////	w.Write(byteArray.Length);
+					////	w.Write(byteArray, 0, byteArray.Length);
+					////	return true;
+					////}
 			}
 
 			return false;

--- a/src/NewRemoting/Server.cs
+++ b/src/NewRemoting/Server.cs
@@ -375,7 +375,7 @@ namespace NewRemoting
 						var task = openTasks[index];
 						if (task.Exception != null)
 						{
-							throw new RemotingException("Unhandled task exception in remote server");
+							throw new RemotingException($"Unhandled task exception in remote server: {task.Exception.Message}", task.Exception);
 						}
 
 						if (task.IsCompleted)


### PR DESCRIPTION
Appears to destabilize the runtime (weird internal runtime exceptions). But cause is unclear. 