### PR TITLE
use a user define log folder

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -77,10 +77,12 @@ jobs:
 
     # Run build
     - name: Run build
+      timeout-minutes: 25
       run: ./build.cmd --target pack --configuration ${{ matrix.configuration }}
 
     # Upload artifacts (to github, not to Nuget)
     - name: Upload artifacts to github
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
          name: artifacts

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -82,7 +82,7 @@ class Build : NukeBuild
 			    .EnableNoBuild()
 			    .EnableNoRestore()
 			    .SetVerbosity(DotNetVerbosity.Normal)
-			    .SetResultsDirectory(RootDirectory / string.Concat("TestResult.UnitTest.", Platform, ".", Configuration, ".", "net6.0"));
+			    .SetSettingsFile("src/NewRemotingUnitTest/test.runsettings");
 		    DotNetTest(settings);
 
 	    });

--- a/src/NewRemoting/ExitCode.cs
+++ b/src/NewRemoting/ExitCode.cs
@@ -1,0 +1,9 @@
+﻿namespace NewRemoting
+{
+	public enum ExitCode
+	{
+		Success = 0,
+		StartFailure = -1, // can happen when certificate file does not exist
+		SocketCreationFailure = -2 // socket port already in used
+	}
+}

--- a/src/NewRemoting/PaExecClient.cs
+++ b/src/NewRemoting/PaExecClient.cs
@@ -382,7 +382,13 @@ namespace NewRemoting
 					clientConnectionLogger?.LogInformation($"Starting remote process: {process.StartInfo.FileName} in {process.StartInfo.WorkingDirectory}");
 					simpleLogger?.Flush();
 
-					process.Start();
+					if (!process.Start())
+					{
+						var msg = "Process failed to start";
+						Logger.LogError(msg);
+						throw new RemotingException(msg);
+					}
+
 					process.BeginOutputReadLine();
 					process.BeginErrorReadLine();
 					Logger.LogInformation("Process started after '{0}'ms", sw.ElapsedMilliseconds);

--- a/src/NewRemoting/PaExecClient.cs
+++ b/src/NewRemoting/PaExecClient.cs
@@ -303,9 +303,7 @@ namespace NewRemoting
 		public virtual IProcess LaunchProcess(CancellationToken externalToken, bool? isRemoteHostOnLocalMachine, string processName, string arguments,
 			string dependenciesFile, string remoteFileDirectory, string paexecArgs = null, ILogger clientConnectionLogger = null)
 		{
-			var simpleLogger = clientConnectionLogger as SimpleLogFileWriter;
 			clientConnectionLogger?.LogInformation($"LaunchProcess {processName}");
-			simpleLogger?.Flush();
 
 			var sw = Stopwatch.StartNew();
 			if (!isRemoteHostOnLocalMachine.HasValue)
@@ -316,7 +314,6 @@ namespace NewRemoting
 			if (!PingUtil.CancellableTryWaitForPingResponse(RemoteHost, TimeSpan.MaxValue, externalToken))
 			{
 				clientConnectionLogger?.LogError($"Could not ping {RemoteHost}");
-				simpleLogger?.Flush();
 				_process = null;
 				return _process;
 			}
@@ -325,7 +322,6 @@ namespace NewRemoting
 			while (_process == null)
 			{
 				clientConnectionLogger?.LogInformation($"Attempting to create remote process");
-				simpleLogger?.Flush();
 
 				if (isRemoteHostOnLocalMachine.Value)
 				{
@@ -338,7 +334,6 @@ namespace NewRemoting
 				_logger.LogInformation("Process created after '{0}'ms", sw.ElapsedMilliseconds);
 
 				clientConnectionLogger?.LogInformation($"Process created after {sw.ElapsedMilliseconds} ms");
-				simpleLogger?.Flush();
 
 				// Cancel operation if process exits or canceled externally
 				lock (_internalCancellationTokenSourceLock)
@@ -380,7 +375,6 @@ namespace NewRemoting
 					Logger.LogInformation(FormattableString.Invariant($"Starting remote process: {process.StartInfo.FileName} in {process.StartInfo.WorkingDirectory}"));
 
 					clientConnectionLogger?.LogInformation($"Starting remote process: {process.StartInfo.FileName} in {process.StartInfo.WorkingDirectory}");
-					simpleLogger?.Flush();
 
 					if (!process.Start())
 					{
@@ -394,12 +388,10 @@ namespace NewRemoting
 					Logger.LogInformation("Process started after '{0}'ms", sw.ElapsedMilliseconds);
 
 					clientConnectionLogger?.LogInformation("Process start called");
-					simpleLogger?.Flush();
 
 					if (WaitForRemoteProcessStartup(linkedCancellationTokenSource, process))
 					{
 						clientConnectionLogger?.LogInformation("Process has started");
-						simpleLogger?.Flush();
 						_process = process; // remote server is running and remote interface is available --> exit the loop
 						break;
 					}
@@ -407,7 +399,6 @@ namespace NewRemoting
 					try
 					{
 						clientConnectionLogger?.LogError("Process start was cancelled");
-						simpleLogger?.Flush();
 
 						// throw canceled exception if it was external canceled
 						externalToken.ThrowIfCancellationRequested();
@@ -418,7 +409,6 @@ namespace NewRemoting
 							var errorMsg = string.Format(CultureInfo.InvariantCulture, "Could not get interface of remote loader on machine {0} ", RemoteHost);
 							Logger.LogError(errorMsg);
 							clientConnectionLogger?.LogError(errorMsg);
-							simpleLogger?.Flush();
 
 							process.Kill(); // if process is still running, we didn't receive the process exit event - this should never happen but just in case we terminate the remote process
 							throw new RemotingException(errorMsg);
@@ -430,7 +420,6 @@ namespace NewRemoting
 							var msg = FormattableString.Invariant($"Paexec service could not be installed, error code {errorCode} - retrying");
 							Logger.LogError(msg);
 							clientConnectionLogger?.LogError(msg);
-							simpleLogger?.Flush();
 						}
 						else
 						{
@@ -438,8 +427,6 @@ namespace NewRemoting
 							Logger.LogError(errorMsg);
 
 							clientConnectionLogger?.LogError(errorMsg);
-							simpleLogger?.Flush();
-
 							throw new RemotingException(errorMsg);
 						}
 					}

--- a/src/NewRemoting/RemoteLoaderWindowsClient.cs
+++ b/src/NewRemoting/RemoteLoaderWindowsClient.cs
@@ -161,9 +161,7 @@ namespace NewRemoting
 		/// <inheritdoc />
 		public void Connect(CancellationToken externalToken, ILogger clientConnectionLogger)
 		{
-			var simpleLogger = Logger as SimpleLogFileWriter;
 			Logger.LogInformation("Connecting to RemotingServer");
-			simpleLogger?.Flush();
 
 			var isRemoteHostOnLocalMachine = NetworkUtil.IsLocalIpAddress(RemoteHost);
 
@@ -179,16 +177,13 @@ namespace NewRemoting
 				{
 					lastError = null;
 					Logger.LogInformation("Creating remoting client");
-					simpleLogger?.Flush();
 					_remotingClient = new Client(RemoteHost, RemotePort, Credentials.Certificate, Logger, clientConnectionLogger);
 					Logger.LogInformation("Remoting client creation succeeded");
-					simpleLogger?.Flush();
 					break;
 				}
 				catch (Exception x) when (x is IOException || x is SocketException || x is UnauthorizedAccessException)
 				{
 					Logger.LogError(x, $"Unable to connect to remote server. Attempt {retries + 1}: {x.Message}");
-					simpleLogger?.Flush();
 					lastError = x;
 
 					if (process is { HasExited: true, ExitCode: -1 })
@@ -204,7 +199,6 @@ namespace NewRemoting
 				catch (Exception x)
 				{
 					Logger.LogError(x, $"Unable to connect to remote server. Attempt {retries + 1}: {x.Message}, aborting");
-					simpleLogger?.Flush();
 					throw;
 				}
 
@@ -214,13 +208,11 @@ namespace NewRemoting
 			if (lastError != null)
 			{
 				Logger.LogError($"Unable to connect to remote server, aborting");
-				simpleLogger?.Flush();
 				throw lastError;
 			}
 
 			_remoteServer = _remotingClient.RequestRemoteInstance<IRemoteServerService>();
 			Logger.LogInformation("Got interface to {0}", _remoteServer.GetType().Name);
-			simpleLogger?.Flush();
 			if (_remoteServer == null)
 			{
 				throw new RemotingException("Could not connect to remote loader interface");
@@ -233,7 +225,6 @@ namespace NewRemoting
 			}
 
 			Logger.LogInformation("BinaryUpload start");
-			simpleLogger?.Flush();
 			Stopwatch sw = Stopwatch.StartNew();
 			// if the remote host is not a local machine we have to upload all necessary binaries and files
 			if (!isRemoteHostOnLocalMachine)
@@ -243,14 +234,11 @@ namespace NewRemoting
 			}
 
 			Logger.LogInformation("BinaryUpload finished after '{0}'ms", sw.ElapsedMilliseconds);
-			simpleLogger?.Flush();
 		}
 
 		public bool Connect(bool checkExistingInstance, CancellationToken cancellationToken, ILogger clientConnectionLogger = null)
 		{
 			clientConnectionLogger?.LogInformation($"Connection sequence for {REMOTELOADER_EXECUTABLE} started.");
-			var simpleLogger = clientConnectionLogger as SimpleLogFileWriter;
-			simpleLogger?.Flush();
 
 			if (checkExistingInstance)
 			{
@@ -262,14 +250,12 @@ namespace NewRemoting
 					if (processes.Length > 0)
 					{
 						clientConnectionLogger?.LogInformation($"{REMOTELOADER_EXECUTABLE} process already exist.");
-						simpleLogger?.Flush();
 						return false;
 					}
 				}
 				else
 				{
 					clientConnectionLogger?.LogInformation($"checking if {REMOTELOADER_EXECUTABLE} process already exist.");
-					simpleLogger?.Flush();
 					var workingDir = Environment.GetFolderPath(Environment.SpecialFolder.System);
 					var powershell = "powershell";
 					// if the process count is greater than 0
@@ -283,21 +269,17 @@ namespace NewRemoting
 						using (var proc = remoteConsole.CreateProcess(powershell + " " + args, enableUserInterfaceInteraction: false, fileListPath: null, workingDirectory: workingDir, redirectStandardOutput: true, redirectStandardError: true))
 						{
 							clientConnectionLogger?.LogInformation("powershell command about to start.");
-							simpleLogger?.Flush();
 							proc.Start();
 							while (!proc.HasExited && !combinedCancellation.IsCancellationRequested)
 							{
 								clientConnectionLogger?.LogInformation("waiting for powershell command process to exit.");
-								simpleLogger?.Flush();
 								proc.WaitForExit(100);
 							}
 
 							if (combinedCancellation.IsCancellationRequested)
 							{
 								clientConnectionLogger?.LogError($"Timeout waiting starting remote process {REMOTELOADER_EXECUTABLE}.");
-								simpleLogger?.Flush();
-								throw new OperationCanceledException(
-									$"Timeout waiting starting remote process {REMOTELOADER_EXECUTABLE}.");
+								throw new OperationCanceledException($"Timeout waiting starting remote process {REMOTELOADER_EXECUTABLE}.");
 							}
 
 							var err = proc.StandardError.ReadToEnd();
@@ -305,7 +287,6 @@ namespace NewRemoting
 							if (!string.IsNullOrEmpty(err))
 							{
 								clientConnectionLogger?.LogWarning($"Powershell standard error output {err}.");
-								simpleLogger?.Flush();
 							}
 
 							if (proc.HasExited && proc.ExitCode == 0)
@@ -314,7 +295,6 @@ namespace NewRemoting
 								if (output.StartsWith("True"))
 								{
 									clientConnectionLogger?.LogWarning($"{REMOTELOADER_EXECUTABLE} process already exist on the remote machine.");
-									simpleLogger?.Flush();
 									return false;
 								}
 							}
@@ -328,7 +308,6 @@ namespace NewRemoting
 			}
 
 			clientConnectionLogger?.LogInformation("Starting Connection to remote server.");
-			simpleLogger?.Flush();
 			Connect(cancellationToken, clientConnectionLogger);
 			return true;
 		}

--- a/src/NewRemoting/RemoteLoaderWindowsClient.cs
+++ b/src/NewRemoting/RemoteLoaderWindowsClient.cs
@@ -185,9 +185,9 @@ namespace NewRemoting
 					Logger.LogError(x, $"Unable to connect to remote server. Attempt {retries + 1}: {x.Message}");
 					lastError = x;
 
-					if (process is { HasExited: true, ExitCode: -1 })
+					if (process is { HasExited: true, ExitCode: (int)ExitCode.StartFailure })
 					{
-						var ex = new RemotingException(message: "Process exited with exit code -1.")
+						var ex = new RemotingException(message: $"Process exited with exit code {(int)ExitCode.StartFailure}.")
 						{
 							AdditionalInfo = RemotingExceptionAdditionalInfo.ProcessStartFailure
 						};

--- a/src/NewRemoting/RemoteLoaderWindowsClient.cs
+++ b/src/NewRemoting/RemoteLoaderWindowsClient.cs
@@ -146,7 +146,6 @@ namespace NewRemoting
 
 		protected override bool WaitForRemoteProcessStartup(CancellationTokenSource linkedCancellationTokenSource, IProcess process)
 		{
-			// TODO: Implement FCMS-8056
 			Thread.Sleep(1000);
 			if (process.HasExited)
 			{

--- a/src/NewRemoting/SimpleLogFileWriter.cs
+++ b/src/NewRemoting/SimpleLogFileWriter.cs
@@ -63,6 +63,7 @@ namespace NewRemoting
 				lock (_writer)
 				{
 					_writer.WriteLine(formatted);
+					_writer.Flush();
 				}
 			}
 		}

--- a/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
+++ b/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
@@ -50,13 +50,7 @@ namespace NewRemotingUnitTest
 			[Test]
 			public void CorrectlyHandleAlreadyExistingRemoteLoader()
 			{
-				string withAuth = _helper != null ? "with" : "none";
-				var now = DateTime.UtcNow.ToString("yyyyMMdd_hhmmsf");
-				string logFile = AppDomain.CurrentDomain.BaseDirectory + $"../../../../../artifacts/CorrectlyHandleAlreadyExistingRemoteLoader_{now}_{withAuth}.log";
-				string clientFile = AppDomain.CurrentDomain.BaseDirectory + $"../../../../../artifacts/CorrectlyHandleAlreadyExistingRemoteLoader_client_{now}_{withAuth}.log";
-				using SimpleLogFileWriter clientLogger = new SimpleLogFileWriter(clientFile, "client");
-				string arguments = $"-v -l {logFile}";
-				var existingProcess = PaExecClient.CreateProcessLocal(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, RemoteLoaderWindowsClient.REMOTELOADER_EXECUTABLE), arguments);
+				var existingProcess = PaExecClient.CreateProcessLocal(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, RemoteLoaderWindowsClient.REMOTELOADER_EXECUTABLE), string.Empty);
 				existingProcess.Start();
 				Assert.IsNotNull(existingProcess);
 				Thread.Sleep(2000);
@@ -64,21 +58,15 @@ namespace NewRemotingUnitTest
 
 				CancellationTokenSource errorTokenSource = new CancellationTokenSource();
 				errorTokenSource.CancelAfter(TimeSpan.FromSeconds(60));
-				logFile = AppDomain.CurrentDomain.BaseDirectory + $"../../../../../artifacts/CorrectlyHandleAlreadyExistingRemoteLoader_second_instance_{now}.log";
-				arguments = $"-v -l {logFile}";
 
-				string remoteLoaderClientLogFile = AppDomain.CurrentDomain.BaseDirectory + $"../../../../../artifacts/CorrectlyHandleAlreadyExistingRemoteLoader_windowsRemotingClient_{now}_{withAuth}.log";
-				using SimpleLogFileWriter remoteLoaderClientLogger = new SimpleLogFileWriter(remoteLoaderClientLogFile, "WindowsRemotingClient");
-
-				using IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), arguments, remoteLoaderClientLogger);
+				using IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), string.Empty);
 				try
 				{
-					client.Connect(errorTokenSource.Token, clientLogger);
-					clientLogger.LogInformation("Client connect done");
+					client.Connect(errorTokenSource.Token);
 				}
 				catch (Exception e)
 				{
-					clientLogger.LogError($"connect has thrown exception {e.Message}");
+					Console.WriteLine($"connect has thrown exception {e.Message}");
 				}
 
 				// Should not be cancelled yet.

--- a/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
+++ b/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 using NewRemoting;
 using NUnit.Framework;
 
@@ -72,8 +73,8 @@ namespace NewRemotingUnitTest
 				using IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), arguments, remoteLoaderClientLogger);
 				try
 				{
-				client.Connect(errorTokenSource.Token, clientLogger);
-				clientLogger.LogInformation("Client connect done");
+					client.Connect(errorTokenSource.Token, clientLogger);
+					clientLogger.LogInformation("Client connect done");
 				}
 				catch (Exception e)
 				{

--- a/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
+++ b/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
@@ -70,8 +70,16 @@ namespace NewRemotingUnitTest
 				using SimpleLogFileWriter remoteLoaderClientLogger = new SimpleLogFileWriter(remoteLoaderClientLogFile, "WindowsRemotingClient");
 
 				using IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), arguments, remoteLoaderClientLogger);
+				try
+				{
 				client.Connect(errorTokenSource.Token, clientLogger);
 				clientLogger.LogInformation("Client connect done");
+				}
+				catch (Exception e)
+				{
+					clientLogger.LogError($"connect has thrown exception {e.Message}");
+				}
+
 				// Should not be cancelled yet.
 				Assert.False(errorTokenSource.IsCancellationRequested);
 				existingProcess.Kill();

--- a/src/NewRemotingUnitTest/test.runsettings
+++ b/src/NewRemotingUnitTest/test.runsettings
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Configurations that affect the Test Framework -->
+  <RunConfiguration>
+	<!-- Use 0 for maximum process-level parallelization. This does not force parallelization within the test DLL (on the thread-level). You can also change it from the Test menu; choose "Run tests in parallel". Unchecked = 1 (only 1), checked = 0 (max). -->
+	<MaxCpuCount>1</MaxCpuCount>
+	<!-- Path relative to directory that contains .runsettings file-->
+	<ResultsDirectory>..\..\artifacts\TestResults</ResultsDirectory>
+
+	<!-- Omit the whole tag for auto-detection. -->
+	<!-- [x86] or x64, ARM, ARM64, s390x  -->
+	<!-- You can also change it from the Test menu; choose "Processor Architecture for AnyCPU Projects" -->
+	<TargetPlatform>x64</TargetPlatform>
+
+	<!-- Any TargetFramework moniker or omit the whole tag for auto-detection. -->
+	<!-- net48, [net40], net6.0, net5.0, netcoreapp3.1, uap10.0 etc. -->
+	<TargetFrameworkVersion>net6.0</TargetFrameworkVersion>
+
+	<!-- Path to Test Adapters -->
+	<!--<TestAdaptersPaths>%SystemDrive%\Temp\foo;%SystemDrive%\Temp\bar</TestAdaptersPaths>-->
+
+	<!-- TestCaseFilter expression -->
+	<TestCaseFilter>(TestCategory != Integration) &amp; (TestCategory != UnfinishedFeature)</TestCaseFilter>
+
+	<!-- TestSessionTimeout was introduced in Visual Studio 2017 version 15.5 -->
+	<!-- Specify timeout in milliseconds. A valid value should be greater than 0 -->
+	<TestSessionTimeout>1200000</TestSessionTimeout>
+
+	<!-- true or false -->
+	<!-- Value that specifies the exit code when no tests are discovered -->
+	<TreatNoTestsAsError>true</TreatNoTestsAsError>
+  </RunConfiguration>
+
+  <!-- Configurations for data collectors -->
+  <DataCollectionRunSettings>
+	<DataCollectors>
+	  <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+		<Configuration>
+		  <CodeCoverage>
+			<ModulePaths>
+			  <Exclude>
+				<ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+			  </Exclude>
+			</ModulePaths>
+
+			<!-- We recommend you do not change the following values: -->
+			<UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+			<AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+			<CollectFromChildProcesses>True</CollectFromChildProcesses>
+			<CollectAspDotNet>False</CollectAspDotNet>
+
+		  </CodeCoverage>
+		</Configuration>
+	  </DataCollector>
+
+	  <DataCollector uri="datacollector://microsoft/VideoRecorder/1.0" assemblyQualifiedName="Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.VideoRecorderDataCollector, Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" friendlyName="Screen and Voice Recorder">
+		<!--Video data collector was introduced in Visual Studio 2017 version 15.5 -->
+		<Configuration>
+		  <!-- Set "sendRecordedMediaForPassedTestCase" to "false" to add video attachments to failed tests only -->
+		  <MediaRecorder sendRecordedMediaForPassedTestCase="true"  xmlns="">
+			​
+			<ScreenCaptureVideo bitRate="512" frameRate="2" quality="20" />​
+		  </MediaRecorder>​
+		</Configuration>
+	  </DataCollector>
+
+	  <!-- Configuration for blame data collector -->
+	  <DataCollector friendlyName="blame" enabled="True">
+	  </DataCollector>
+
+	</DataCollectors>
+  </DataCollectionRunSettings>
+
+  <!-- Parameters used by tests at run time -->
+  <TestRunParameters>
+	<Parameter name="webAppUrl" value="http://localhost" />
+	<Parameter name="webAppUserName" value="Admin" />
+	<Parameter name="webAppPassword" value="Password" />
+  </TestRunParameters>
+
+  <!-- Configuration for loggers -->
+  <LoggerRunSettings>
+	<Loggers>
+	  <Logger friendlyName="console" enabled="True">
+		<Configuration>
+		  <Verbosity>quiet</Verbosity>
+		</Configuration>
+	  </Logger>
+	  <Logger friendlyName="trx" enabled="True">
+		<Configuration>
+		  <LogFilstarteName>testresult.trx</LogFilstarteName>
+		</Configuration>
+	  </Logger>
+	  <Logger friendlyName="html" enabled="True">
+		<Configuration>
+		  <LogFileName>testresult.html</LogFileName>
+		</Configuration>
+	  </Logger>
+	  <Logger friendlyName="blame" enabled="True" />
+	</Loggers>
+  </LoggerRunSettings>
+
+  <!-- Adapter Specific sections -->
+
+  <!-- MSTest adapter -->
+  <MSTest>
+	<MapInconclusiveToFailed>True</MapInconclusiveToFailed>
+	<CaptureTraceOutput>false</CaptureTraceOutput>
+	<DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+	<DeploymentEnabled>False</DeploymentEnabled>
+	<AssemblyResolution>
+	  <Directory path="D:\myfolder\bin\" includeSubDirectories="false"/>
+	</AssemblyResolution>
+  </MSTest>
+
+</RunSettings>

--- a/src/RemotingServer/Program.cs
+++ b/src/RemotingServer/Program.cs
@@ -31,113 +31,105 @@ namespace RemotingServer
 			ILogger logger = null;
 			try
 			{
-			var parsed = Parser.Default.ParseArguments<CommandLineOptions>(args);
-			int port = Client.DefaultNetworkPort;
-			CommandLineOptions options = null;
-			parsed.WithParsed(r => options = r);
-			if (options != null)
-			{
-				if (options.Port.HasValue)
+				var parsed = Parser.Default.ParseArguments<CommandLineOptions>(args);
+				int port = Client.DefaultNetworkPort;
+				CommandLineOptions options = null;
+				parsed.WithParsed(r => options = r);
+				if (options != null)
 				{
-					port = options.Port.Value;
-				}
+					if (options.Port.HasValue)
+					{
+						port = options.Port.Value;
+					}
 
-				if (!string.IsNullOrWhiteSpace(options.LogFile))
+					if (!string.IsNullOrWhiteSpace(options.LogFile))
 				{
 					try
 					{
 						var info = new FileInfo(options.LogFile);
 						info.Directory?.Create();
-							logger = new SimpleLogFileWriter(options.LogFile, "ServerLog",
-								options.Verbose ? LogLevel.Trace : LogLevel.Information);
+						logger = new SimpleLogFileWriter(options.LogFile, "ServerLog", options.Verbose ? LogLevel.Trace : LogLevel.Information);
 					}
 					catch (IOException)
 					{
-							logger = new SimpleLogFileWriter(Path.Combine(Path.GetTempPath(), options.LogFile),
-								"ServerLog",
-							options.Verbose ? LogLevel.Trace : LogLevel.Information);
+						logger = new SimpleLogFileWriter(Path.Combine(Path.GetTempPath(), options.LogFile), "ServerLog", options.Verbose ? LogLevel.Trace : LogLevel.Information);
 					}
 				}
-				else if (options.Verbose)
-				{
-					logger = new ConsoleAndDebugLogger("RemotingServer");
-				}
-
-					Process currentProcess = Process.GetCurrentProcess();
-					logger?.LogInformation($"current process id {currentProcess.Id}");
-
-				var allKeys = ConfigurationManager.AppSettings.AllKeys;
-				string certificate = null;
-				string certPwd = null;
-
-				if (allKeys.Contains("CertificateFileName"))
-				{
-					var cert = ConfigurationManager.AppSettings.Get("CertificateFileName");
-					if (!string.IsNullOrEmpty(cert))
+					else if (options.Verbose)
 					{
-						certificate = cert;
+						logger = new ConsoleAndDebugLogger("RemotingServer");
 					}
-				}
 
-				if (!string.IsNullOrEmpty(certificate))
-				{
-					logger?.LogInformation("Certificate provided to application");
-				}
-				else
-				{
-					logger?.LogInformation("Certificate not provided to application.");
-				}
+					var allKeys = ConfigurationManager.AppSettings.AllKeys;
+					string certificate = null;
+					string certPwd = null;
 
-				if (allKeys.Contains("CertificatePassword"))
-				{
-					certPwd = ConfigurationManager.AppSettings.Get("CertificatePassword");
-					if (!string.IsNullOrEmpty(certPwd))
+					if (allKeys.Contains("CertificateFileName"))
 					{
-						logger?.LogInformation("password provided to application.");
+						var cert = ConfigurationManager.AppSettings.Get("CertificateFileName");
+						if (!string.IsNullOrEmpty(cert))
+						{
+							certificate = cert;
+						}
 					}
-				}
 
-				if (!string.IsNullOrEmpty(certificate))
-				{
-					if (!File.Exists(certificate))
+					if (!string.IsNullOrEmpty(certificate))
 					{
-						Console.WriteLine($"Certificate {certificate} does not exist");
-						return false;
+						logger?.LogInformation("Certificate provided to application");
 					}
-				}
+					else
+					{
+						logger?.LogInformation("Certificate not provided to application.");
+					}
 
-				var server = new Server(port, new AuthenticationInformation(certificate, certPwd), logger);
-				if (options.KillSelf)
-				{
+					if (allKeys.Contains("CertificatePassword"))
+					{
+						certPwd = ConfigurationManager.AppSettings.Get("CertificatePassword");
+						if (!string.IsNullOrEmpty(certPwd))
+						{
+							logger?.LogInformation("password provided to application.");
+						}
+					}
+
+					if (!string.IsNullOrEmpty(certificate))
+					{
+						if (!File.Exists(certificate))
+						{
+							Console.WriteLine($"Certificate {certificate} does not exist");
+							return false;
+						}
+					}
+
+					var server = new Server(port, new AuthenticationInformation(certificate, certPwd), logger);
+					if (options.KillSelf)
+					{
+						server.KillProcessWhenChannelDisconnected = true;
+					}
+
+					// Temporary (Need to move the server creation logic to the library)
 					server.KillProcessWhenChannelDisconnected = true;
+
+					server.StartListening();
+					server.WaitForTermination();
+					server.Terminate(false);
+					GC.KeepAlive(server);
+					if (logger is IDisposable disposable)
+					{
+						disposable.Dispose();
+					}
 				}
 
-				// Temporary (Need to move the server creation logic to the library)
-				server.KillProcessWhenChannelDisconnected = true;
-
-				server.StartListening();
-				server.WaitForTermination();
-				server.Terminate(false);
-				GC.KeepAlive(server);
-				if (logger is IDisposable disposable)
-				{
-					disposable.Dispose();
-				}
+				return true;
 			}
-
-			return true;
-		}
 			catch (SocketException e)
 			{
 				Console.WriteLine(e);
-				var process = Process.GetCurrentProcess();
-				logger?.LogError(e, $"start server failed, process id {process.Id}");
+				logger?.LogError(e, "start server failed");
 				return false;
-	}
+			}
 			finally
 			{
-				var process = Process.GetCurrentProcess();
-				logger?.LogInformation($"end of startserver ({process.Id})");
+				logger?.LogInformation("end of program");
 			}
 		}
 	}

--- a/src/RemotingServer/Program.cs
+++ b/src/RemotingServer/Program.cs
@@ -41,8 +41,17 @@ namespace RemotingServer
 
 				if (!string.IsNullOrWhiteSpace(options.LogFile))
 				{
-					// logfile argument is expected to be without root path (as it is called remotely without knowledge of local paths)
-					logger = new SimpleLogFileWriter(Path.Combine(Path.GetTempPath(), options.LogFile), "ServerLog", options.Verbose ? LogLevel.Trace : LogLevel.Information);
+					try
+					{
+						var info = new FileInfo(options.LogFile);
+						info.Directory?.Create();
+						logger = new SimpleLogFileWriter(options.LogFile, "ServerLog", options.Verbose ? LogLevel.Trace : LogLevel.Information);
+					}
+					catch (IOException)
+					{
+						logger = new SimpleLogFileWriter(Path.Combine(Path.GetTempPath(), options.LogFile), "ServerLog",
+							options.Verbose ? LogLevel.Trace : LogLevel.Information);
+					}
 				}
 				else if (options.Verbose)
 				{

--- a/src/RemotingServer/Program.cs
+++ b/src/RemotingServer/Program.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using Castle.Core.Internal;
 using CommandLine;
 using Microsoft.Extensions.Logging;
@@ -126,12 +127,12 @@ namespace RemotingServer
 
 			return true;
 		}
-			catch (Exception e)
+			catch (SocketException e)
 			{
 				Console.WriteLine(e);
 				var process = Process.GetCurrentProcess();
-				logger?.LogError($"process {process.Id} start server failed {e.Message}");
-				throw;
+				logger?.LogError(e, $"start server failed, process id {process.Id}");
+				return false;
 	}
 			finally
 			{
@@ -139,6 +140,5 @@ namespace RemotingServer
 				logger?.LogInformation($"end of startserver ({process.Id})");
 			}
 		}
-
 	}
 }

--- a/src/RemotingServer/Program.cs
+++ b/src/RemotingServer/Program.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
-using Castle.Core.Internal;
 using CommandLine;
 using Microsoft.Extensions.Logging;
 using NewRemoting;
@@ -16,17 +14,12 @@ namespace RemotingServer
 		public static int Main(string[] args)
 		{
 			Console.WriteLine("Hello World of Remoting Servers!");
-			if (!StartServer(args))
-			{
-				Console.WriteLine("Server failed to start.");
-				return -1;
-			}
-
-			Console.WriteLine("Server gracefully exiting");
-			return 0;
+			var exitCode = StartServer(args);
+			Console.WriteLine(exitCode != ExitCode.Success ? "Server failed to start." : "Server gracefully exiting");
+			return (int)exitCode;
 		}
 
-		public static bool StartServer(string[] args)
+		public static ExitCode StartServer(string[] args)
 		{
 			ILogger logger = null;
 			try
@@ -96,7 +89,7 @@ namespace RemotingServer
 						if (!File.Exists(certificate))
 						{
 							Console.WriteLine($"Certificate {certificate} does not exist");
-							return false;
+							return ExitCode.StartFailure;
 						}
 					}
 
@@ -119,13 +112,13 @@ namespace RemotingServer
 					}
 				}
 
-				return true;
+				return ExitCode.Success;
 			}
 			catch (SocketException e)
 			{
 				Console.WriteLine(e);
 				logger?.LogError(e, "start server failed");
-				return false;
+				return ExitCode.SocketCreationFailure;
 			}
 			finally
 			{


### PR DESCRIPTION
- catch the remoting exception thrown when the second instance of remoting server is created, in problematic unit test
- always flush in simplelogwriter
- catch the socket exception in remotingServer startServer
