### PR TITLE
Add possibility to add external serializers

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 # current development version which is first version of next release branched away from master
-next-version: 1.0.0
+next-version: 1.0.1
 
 # configuration for all branches
 assembly-versioning-scheme: MajorMinorPatchTag

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 # current development version which is first version of next release branched away from master
-next-version: 1.0.1
+next-version: 1.1.0
 
 # configuration for all branches
 assembly-versioning-scheme: MajorMinorPatchTag

--- a/src/NewRemoting/Client.cs
+++ b/src/NewRemoting/Client.cs
@@ -56,6 +56,19 @@ namespace NewRemoting
 		/// <param name="port">Network port</param>
 		/// <param name="authenticationInformation"> credentials for authentication</param>
 		/// <param name="settings">Advanced connection settings</param>
+		public Client(string server, int port, AuthenticationInformation authenticationInformation,
+			ConnectionSettings settings)
+			: this(server, port, authenticationInformation, settings, new List<JsonConverter>())
+		{
+		}
+
+		/// <summary>
+		/// Creates a remoting client for the given server and opens the network connection
+		/// </summary>
+		/// <param name="server">Server name or IP</param>
+		/// <param name="port">Network port</param>
+		/// <param name="authenticationInformation"> credentials for authentication</param>
+		/// <param name="settings">Advanced connection settings</param>
 		/// <param name="extraConverters">A list of separate type-to-json converters. The use of <see cref="IManualSerialization"/> is preferred, though</param>
 		public Client(string server, int port, AuthenticationInformation authenticationInformation, ConnectionSettings settings, IList<JsonConverter> extraConverters)
 		{

--- a/src/NewRemoting/FormatterFactory.cs
+++ b/src/NewRemoting/FormatterFactory.cs
@@ -68,6 +68,11 @@ namespace NewRemoting
 			_cusBinaryFormatters.Clear();
 		}
 
+		public IList<JsonConverter> GetExternalSurrogates()
+		{
+			return _externalSurrogateList;
+		}
+
 		public JsonSerializerOptions CreateOrGetFormatter(string otherSideProcessId)
 		{
 			if (_cusBinaryFormatters.TryGetValue(otherSideProcessId, out var formatter))

--- a/src/NewRemoting/IRemoteLoaderClient.cs
+++ b/src/NewRemoting/IRemoteLoaderClient.cs
@@ -38,6 +38,15 @@ namespace NewRemoting
 		/// Connects the remote loader to the remote system;
 		/// </summary>
 		/// <param name="cancellationToken">Abort token for connection attempt</param>
+		/// <param name="clientConnectionLogger">A logger for logging all communication activities. Use for debugging only, as it has a
+		/// performance penalty</param>
+		/// <exception cref="RemotingException">Thrown if connection to remote loader fails</exception>
+		void Connect(CancellationToken cancellationToken, ILogger clientConnectionLogger);
+
+		/// <summary>
+		/// Connects the remote loader to the remote system;
+		/// </summary>
+		/// <param name="cancellationToken">Abort token for connection attempt</param>
 		/// <param name="extraSurrogates">A list of extra converters</param>
 		/// <param name="clientConnectionLogger">A logger for logging all communication activities. Use for debugging only, as it has a
 		/// performance penalty</param>

--- a/src/NewRemoting/IRemoteLoaderClient.cs
+++ b/src/NewRemoting/IRemoteLoaderClient.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 
@@ -36,10 +38,11 @@ namespace NewRemoting
 		/// Connects the remote loader to the remote system;
 		/// </summary>
 		/// <param name="cancellationToken">Abort token for connection attempt</param>
+		/// <param name="extraSurrogates">A list of extra converters</param>
 		/// <param name="clientConnectionLogger">A logger for logging all communication activities. Use for debugging only, as it has a
 		/// performance penalty</param>
 		/// <exception cref="RemotingException">Thrown if connection to remote loader fails</exception>
-		void Connect(CancellationToken cancellationToken, ILogger clientConnectionLogger = null);
+		void Connect(CancellationToken cancellationToken, IList<JsonConverter> extraSurrogates, ILogger clientConnectionLogger);
 
 		/// <summary>
 		/// Connects the remote loader to the remote system; Fails if an instance already exists.
@@ -47,12 +50,13 @@ namespace NewRemoting
 		/// </summary>
 		/// <param name="checkExistingInstance">If true a check of existing process with same name is done on the remote host</param>
 		/// <param name="cancellationToken">Abort token for connection attempt</param>
+		/// <param name="extraSurrogates">A set of extra converters</param>
 		/// <param name="clientConnectionLogger">A logger for logging all communication activities. Use for debugging only, as it has a
 		/// performance penalty</param>
 		/// <returns>Return true if a new instance of the remoting server is launched, false if an instance already exists</returns>
 		/// <exception cref="RemotingException">Thrown if connection to remote loader fails. Or if the remote command to get the running process fails</exception>
 		/// <exception cref="OperationCanceledException">Thrown if timeout occurs or cancellation</exception>
-		bool Connect(bool checkExistingInstance, CancellationToken cancellationToken, ILogger clientConnectionLogger = null);
+		bool Connect(bool checkExistingInstance, CancellationToken cancellationToken, IList<JsonConverter> extraSurrogates, ILogger clientConnectionLogger);
 
 		/// <summary>
 		/// Creates an object in a host process on a remote machine.

--- a/src/NewRemoting/IRemoteServerService.cs
+++ b/src/NewRemoting/IRemoteServerService.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace NewRemoting
 {
+	/// <summary>
+	/// This interface offers some services the server is always providing for it's own use.
+	/// </summary>
 	public interface IRemoteServerService
 	{
 		/// <summary>
@@ -93,5 +96,7 @@ namespace NewRemoting
 		/// Performs a server side GC
 		/// </summary>
 		void PerformGc();
+
+		void RegisterConverters(IList<Type> converters);
 	}
 }

--- a/src/NewRemoting/RemoteLoaderWindowsClient.cs
+++ b/src/NewRemoting/RemoteLoaderWindowsClient.cs
@@ -160,6 +160,12 @@ namespace NewRemoting
 			return true;
 		}
 
+		/// <inheritdoc/>
+		public void Connect(CancellationToken externalToken, ILogger clientConnectionLogger)
+		{
+			Connect(externalToken, new List<JsonConverter>(), clientConnectionLogger);
+		}
+
 		/// <inheritdoc />
 		public void Connect(CancellationToken externalToken, IList<JsonConverter> extraSurrogates, ILogger clientConnectionLogger)
 		{

--- a/src/NewRemoting/RemoteServerService.cs
+++ b/src/NewRemoting/RemoteServerService.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace NewRemoting
@@ -228,6 +229,11 @@ namespace NewRemoting
 			GC.WaitForPendingFinalizers();
 			GC.WaitForFullGCComplete();
 			_server.PerformGc();
+		}
+
+		public void RegisterConverters(IList<Type> surrogateTypes)
+		{
+			_server.AddExternalSurrogates(surrogateTypes);
 		}
 
 		/// <summary>

--- a/src/NewRemoting/Server.cs
+++ b/src/NewRemoting/Server.cs
@@ -14,6 +14,7 @@ using System.Runtime.Serialization;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,6 +166,25 @@ namespace NewRemoting
 			{
 				ServiceContainer.AddService(typeof(IRemoteServerService), new RemoteServerService(this, Logger));
 			}
+		}
+
+		internal void AddExternalSurrogates(IList<Type> surrogateTypes)
+		{
+			foreach (var c in surrogateTypes)
+			{
+				if (!c.IsAssignableTo(typeof(JsonConverter)))
+				{
+					throw new InvalidOperationException("Type converters must be a subtype of JsonConverter");
+				}
+
+				var obj = (JsonConverter)Activator.CreateInstance(c, BindingFlags.CreateInstance, null, null, null);
+				_formatterFactory.AddExternalSurrogate(obj);
+			}
+		}
+
+		internal void AddExternalSurrogates(IList<JsonConverter> extraConverters)
+		{
+			_formatterFactory.AddExternalSurrogates(extraConverters);
 		}
 
 		private Assembly AssemblyResolver(object sender, ResolveEventArgs args)

--- a/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
+++ b/src/NewRemotingUnitTest/RemoteLoaderClientTest.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json.Serialization;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using NewRemoting;
@@ -71,7 +73,7 @@ namespace NewRemotingUnitTest
 				// if the socket exception already happened we catch the remotingException throw after the one second wait.
 				try
 				{
-					client.Connect(errorTokenSource.Token);
+					client.Connect(errorTokenSource.Token, null);
 				}
 				catch (RemotingException e)
 				{
@@ -139,7 +141,7 @@ namespace NewRemotingUnitTest
 				using (IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), string.Empty))
 				{
 					CancellationTokenSource errorTokenSource = new CancellationTokenSource();
-					Assert.That(client.Connect(true, errorTokenSource.Token, null));
+					Assert.That(client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
 				}
 			}
 
@@ -149,8 +151,8 @@ namespace NewRemotingUnitTest
 				using (IRemoteLoaderClient client = new RemoteLoaderWindowsClient(_remoteCredentials, "127.0.0.1", Client.DefaultNetworkPort, new FileHashCalculator(), f => true, TimeSpan.FromSeconds(2), string.Empty))
 				{
 					CancellationTokenSource errorTokenSource = new CancellationTokenSource();
-					Assert.That(client.Connect(true, errorTokenSource.Token, null));
-					Assert.That(!client.Connect(true, errorTokenSource.Token, null));
+					Assert.That(client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
+					Assert.That(!client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
 				}
 			}
 
@@ -277,7 +279,7 @@ namespace NewRemotingUnitTest
 				{
 					// check if cancellation works, timeout here is shorter than the 10 seconds one in Connect implementation
 					CancellationTokenSource timeoutCts = new CancellationTokenSource(100);
-					Assert.Throws<OperationCanceledException>(() => client.Connect(true, timeoutCts.Token, null));
+					Assert.Throws<OperationCanceledException>(() => client.Connect(true, timeoutCts.Token, new List<JsonConverter>(), null));
 				}
 			}
 
@@ -287,7 +289,7 @@ namespace NewRemotingUnitTest
 				using (IRemoteLoaderClient client = new RemoteLoaderFactory().Create(RemoteCredentials, "wrongRemote"))
 				{
 					CancellationTokenSource errorTokenSource = new CancellationTokenSource();
-					Assert.Throws<RemotingException>(() => client.Connect(true, errorTokenSource.Token, null));
+					Assert.Throws<RemotingException>(() => client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
 				}
 			}
 
@@ -297,7 +299,7 @@ namespace NewRemotingUnitTest
 				using (IRemoteLoaderClient client = new RemoteLoaderFactory().Create(RemoteCredentials, RemoteHost))
 				{
 					CancellationTokenSource errorTokenSource = new CancellationTokenSource();
-					Assert.That(client.Connect(true, errorTokenSource.Token, null));
+					Assert.That(client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
 				}
 			}
 
@@ -307,8 +309,8 @@ namespace NewRemotingUnitTest
 				using (IRemoteLoaderClient client = new RemoteLoaderFactory().Create(RemoteCredentials, RemoteHost))
 				{
 					CancellationTokenSource errorTokenSource = new CancellationTokenSource();
-					Assert.That(client.Connect(true, errorTokenSource.Token, null));
-					Assert.That(!client.Connect(true, errorTokenSource.Token, null));
+					Assert.That(client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
+					Assert.That(!client.Connect(true, errorTokenSource.Token, new List<JsonConverter>(), null));
 				}
 			}
 

--- a/src/NewRemotingUnitTest/ServerTerminationTest.cs
+++ b/src/NewRemotingUnitTest/ServerTerminationTest.cs
@@ -6,6 +6,7 @@ using System.Management;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Castle.DynamicProxy;

--- a/src/RemotingClient/Program.cs
+++ b/src/RemotingClient/Program.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using System.Threading;
 using CommandLine;
 using Microsoft.Extensions.Logging;
@@ -181,7 +183,7 @@ namespace RemotingClient
 						InstanceManagerLogger = logWriter,
 					};
 
-					Client client = new Client(ip, Client.DefaultNetworkPort, certificate, settings);
+					Client client = new Client(ip, Client.DefaultNetworkPort, certificate, settings, new List<JsonConverter>());
 					return client;
 				}
 				catch (SocketException x)

--- a/src/SampleServerClasses/ClassRequiringExternalSerialization.cs
+++ b/src/SampleServerClasses/ClassRequiringExternalSerialization.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SampleServerClasses
+{
+	/// <summary>
+	/// This doesn't really _need_ external serialization, but we use it for testing that
+	/// </summary>
+	public class ClassRequiringExternalSerialization
+	{
+		public ClassRequiringExternalSerialization(string data1)
+		{
+			Data1 = data1;
+			WasSerialized = false;
+		}
+
+		public string Data1 { get; set; }
+
+		public bool WasSerialized
+		{
+			get;
+			set;
+		}
+	}
+}

--- a/src/SampleServerClasses/MarshallableClass.cs
+++ b/src/SampleServerClasses/MarshallableClass.cs
@@ -410,5 +410,10 @@ namespace SampleServerClasses
 
 			return handles;
 		}
+
+		public virtual ClassRequiringExternalSerialization CheckExternalSerialization(string data)
+		{
+			return new ClassRequiringExternalSerialization(data);
+		}
 	}
 }

--- a/src/SampleServerClasses/TransientServer.cs
+++ b/src/SampleServerClasses/TransientServer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using NewRemoting;
 
@@ -23,7 +24,7 @@ namespace SampleServerClasses
 			_serverProcess = Process.Start("RemotingServer.exe", $"-p {port}");
 
 			// Port is currently hardcoded
-			_client = new Client("localhost", port, null, new ConnectionSettings());
+			_client = new Client("localhost", port, null, new ConnectionSettings(), new List<JsonConverter>());
 			_remoteOperationsServer = _client.RequestRemoteInstance<IRemoteServerService>();
 			if (_remoteOperationsServer == null)
 			{


### PR DESCRIPTION
The feature is required currently for UnitsNet types. Those fail serialization using System.Text.Json. 