### PR TITLE
Make sure CancellationToken is not used incorrectly across processes

### DIFF
--- a/src/NewRemoting/RemotingReferenceType.cs
+++ b/src/NewRemoting/RemotingReferenceType.cs
@@ -39,6 +39,7 @@ namespace NewRemoting
 		AddEvent,
 		RemoveEvent,
 		MethodPointer,
-		ByteArray
+		ByteArray,
+		CancellationToken,
 	}
 }

--- a/src/SampleServerClasses/DummyCancellableType.cs
+++ b/src/SampleServerClasses/DummyCancellableType.cs
@@ -20,12 +20,17 @@ namespace SampleServerClasses
 			cancellationToken.ThrowIfCancellationRequested();
 		}
 
-		public virtual void DoSomethingWithNormalToken(ICrossAppDomainCancellationToken cancellationToken)
+		public virtual void WaitForToken(ICrossAppDomainCancellationToken cancellationToken)
 		{
-			TakeToken(cancellationToken.GetLocalCancellationToken());
+			WaitForCancellation(cancellationToken.GetLocalCancellationToken());
 		}
 
-		private void TakeToken(CancellationToken token)
+		public virtual void DoSomethingWithNormalToken(CancellationToken cancellationToken)
+		{
+			WaitForCancellation(cancellationToken);
+		}
+
+		private void WaitForCancellation(CancellationToken token)
 		{
 			Stopwatch w = Stopwatch.StartNew();
 			while (true)
@@ -36,6 +41,7 @@ namespace SampleServerClasses
 				}
 
 				token.ThrowIfCancellationRequested();
+				Thread.Sleep(100);
 			}
 		}
 	}


### PR DESCRIPTION
The standard types CancellationToken and CancellationTokenSource can't be used in a remote call, because their underlying infrastructure is not serializable. With this PR, attempting to do so causes an immediate exception (except if the CancellationToken is set to None or cancelled already)